### PR TITLE
Pin nifty to build version 4

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -6,6 +6,8 @@ name:
     synapse-net
 dependencies:
     - bioimageio.core
+    - # This pin is necessary because later nifty versions have import errors on windows.
+    - nifty =1.2.1=*_4
     - kornia
     - magicgui
     - napari

--- a/environment_cpu.yaml
+++ b/environment_cpu.yaml
@@ -4,6 +4,8 @@ name:
     synapse-net
 dependencies:
     - bioimageio.core
+    # This pin is necessary because later nifty versions have import errors on windows.
+    - nifty =1.2.1=*_4
     - kornia
     - magicgui
     - napari


### PR DESCRIPTION
It seems the `nifty` issue persists for windows users (and there are packages which implicitly install the latest nifty build). I propose we pin it to a working version!

Reference: https://github.com/computational-cell-analytics/synapse-net/issues/90