### PR TITLE
added foreground threshold to hmap

### DIFF
--- a/synapse_net/inference/mitochondria.py
+++ b/synapse_net/inference/mitochondria.py
@@ -33,7 +33,7 @@ def _run_segmentation(
 
     t0 = time.time()
     hmap = (dist.max() - dist) / dist.max()
-    hmap[boundaries > boundary_threshold] = (hmap + boundaries).max()
+    hmap[np.logical_and(boundaries > boundary_threshold, foreground < boundary_threshold)] = (hmap + boundaries).max()
     mask = (foreground + boundaries) > 0.5
 
     seg = np.zeros_like(seeds)


### PR DESCRIPTION
@constantinpape 
The hmap now has peaks inside mitochondria (I assume some cristae are picked up as boundaries).
To prevent this, I added a foreground threshold that prevents this misclassification from contributing to the hmap. 